### PR TITLE
Add --version, link Static for release

### DIFF
--- a/inc/TextToolsCommon.h
+++ b/inc/TextToolsCommon.h
@@ -4,6 +4,13 @@
 #pragma once
 #include <memory>
 
+#define TEXTTOOLS_VERSION "v1.0.1"
+#define TEXTTOOLS_LICENSE "Distributed under the terms of the MIT License.\nWritten by Doug Cook."
+
+#define TEXTTOOLS_VERSION_STR(toolNameString) "\n" \
+    toolNameString " (TextUtils) " TEXTTOOLS_VERSION "\n" \
+    TEXTTOOLS_LICENSE "\n" \
+
 namespace TextToolsImpl
 {
     struct CloseHandle_delete

--- a/lib/TextToolsLib.vcxproj
+++ b/lib/TextToolsLib.vcxproj
@@ -126,6 +126,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>../inc</AdditionalIncludeDirectories>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>
@@ -167,6 +168,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>../inc</AdditionalIncludeDirectories>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>

--- a/wargs/Program.cpp
+++ b/wargs/Program.cpp
@@ -5,6 +5,7 @@
 #include "WArgs.h"
 
 #include <ArgParser.h>
+#include <TextToolsCommon.h>
 
 static int
 Usage()
@@ -51,6 +52,7 @@ If no COMMAND is specified, the default command is echo (cmd.exe /c echo).
                              argument would force the command line to exceed
                              MAXCHARS.
 -h, -?, --help               Show this usage information and then exit.
+--version                    Show the version number of wargs and then exit.
 
 ENCODING names ignore case and punctuation (e.g. 'utf-8' is the same as
 'UTF8'). They may be formatted as digits (Windows code page identifier), 'CP'
@@ -63,6 +65,13 @@ UTF encoding should override the specified encoding.
     return 1;
 }
 
+static int
+Version()
+{
+    fputs(TEXTTOOLS_VERSION_STR("wargs"), stdout);
+    return 1;
+}
+
 int __cdecl
 wmain(int argc, _In_count_(argc) PWSTR argv[])
 {
@@ -72,6 +81,7 @@ wmain(int argc, _In_count_(argc) PWSTR argv[])
     {
         WArgs wargs;
         bool showHelp = false;
+        bool showVersion = false;
         exitCode = 0;
 
         ArgParser ap(AppName, argc, argv);
@@ -180,9 +190,13 @@ wmain(int argc, _In_count_(argc) PWSTR argv[])
                 {
                     wargs.SetShowLimits();
                 }
-                else if (ap.CurrentArgNameMatches(1, L"verbose"))
+                else if (ap.CurrentArgNameMatches(4, L"verbose"))
                 {
                     wargs.SetVerbose();
+                }
+                else if (ap.CurrentArgNameMatches(4, L"version"))
+                {
+                    showVersion = true;
                 }
                 else
                 {
@@ -292,6 +306,10 @@ wmain(int argc, _In_count_(argc) PWSTR argv[])
         if (showHelp)
         {
             exitCode = Usage();
+        }
+        else if (showVersion)
+        {
+            exitCode = Version();
         }
         else if (ap.ArgError())
         {

--- a/wargs/wargs.vcxproj
+++ b/wargs/wargs.vcxproj
@@ -122,6 +122,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>../inc</AdditionalIncludeDirectories>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -163,6 +164,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>../inc</AdditionalIncludeDirectories>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/wconv/Program.cpp
+++ b/wconv/Program.cpp
@@ -5,6 +5,7 @@
 #include "WConv.h"
 
 #include <ArgParser.h>
+#include <TextToolsCommon.h>
 
 static int
 Usage()
@@ -40,6 +41,7 @@ Converts text from one encoding to another. Similar to the "iconv" tool.
 
 If -l or --list is specified, show supported encodings and exit.
 If -h or --help is specified, show usage and exit.
+If --version is specified, show the version number of wconv and then exit.
 
 ENCODING names ignore case and punctuation (e.g. 'utf-8' is the same as
 'UTF8'). They may be formatted as digits (Windows code page identifier), 'CP'
@@ -71,6 +73,13 @@ Examples:
     return 1;
 }
 
+static int
+Version()
+{
+    fputs(TEXTTOOLS_VERSION_STR("wconv"), stdout);
+    return 1;
+}
+
 int __cdecl
 wmain(int argc, _In_count_(argc) PWSTR argv[])
 {
@@ -80,6 +89,7 @@ wmain(int argc, _In_count_(argc) PWSTR argv[])
     {
         WConv wconv;
         bool showHelp = false;
+        bool showVersion = false;
         bool showList = false;
 
         ArgParser ap(AppName, argc, argv);
@@ -171,6 +181,10 @@ wmain(int argc, _In_count_(argc) PWSTR argv[])
                         ap.SetArgErrorIfFalse(wconv.SetOutputEncoding(val, "--to-code"));
                     }
                 }
+                else if (ap.CurrentArgNameMatches(1, L"version"))
+                {
+                    showVersion = true;
+                }
                 else
                 {
                     ap.PrintLongArgError();
@@ -243,6 +257,10 @@ wmain(int argc, _In_count_(argc) PWSTR argv[])
         if (showHelp)
         {
             returnCode = Usage();
+        }
+        else if (showVersion)
+        {
+            returnCode = Version();
         }
         else if (ap.ArgError())
         {

--- a/wconv/wconv.vcxproj
+++ b/wconv/wconv.vcxproj
@@ -122,6 +122,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>../inc</AdditionalIncludeDirectories>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>
@@ -163,6 +164,7 @@
       <LanguageStandard>stdcpp20</LanguageStandard>
       <AdditionalIncludeDirectories>../inc</AdditionalIncludeDirectories>
       <EnforceTypeConversionRules>true</EnforceTypeConversionRules>
+      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>


### PR DESCRIPTION
- Add a `--version` option.
- Release builds should use the static CRT for convenience.